### PR TITLE
Update CodeBuild Compute Type

### DIFF
--- a/nuke-cfn-stack.yaml
+++ b/nuke-cfn-stack.yaml
@@ -237,7 +237,7 @@ Resources:
         - Key: owner
           Value: !Ref Owner
       Environment:
-        ComputeType: BUILD_GENERAL1_2XLARGE
+        ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/docker:18.09.0
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true


### PR DESCRIPTION
The CodeBuild Compute Type is set to BUILD_GENERAL1_2XLARGE causing an unexpectedly large cost to run this tool. Compute type has been dropped down to BUILD_GENERAL1_SMALL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
